### PR TITLE
Make Atari ST font names more descriptive

### DIFF
--- a/atari/st/atari-st-16x32.yaff
+++ b/atari/st/atari-st-16x32.yaff
@@ -1,4 +1,4 @@
-name: 16x32 system font
+name: Atari ST 16x32
 spacing: character-cell
 cell-size: 16 32
 point-size: 20

--- a/atari/st/atari-st-6x6.yaff
+++ b/atari/st/atari-st-6x6.yaff
@@ -1,4 +1,4 @@
-name: 6x6 system font
+name: Atari ST 6x6
 spacing: character-cell
 cell-size: 6 6
 point-size: 8

--- a/atari/st/atari-st-8x16.yaff
+++ b/atari/st/atari-st-8x16.yaff
@@ -1,4 +1,4 @@
-name: 8x16 system font
+name: Atari ST 8x16
 spacing: character-cell
 cell-size: 8 16
 point-size: 10

--- a/atari/st/atari-st-8x8.yaff
+++ b/atari/st/atari-st-8x8.yaff
@@ -1,4 +1,4 @@
-name: 8x8 system font
+name: Atari ST 8x8
 spacing: character-cell
 cell-size: 8 8
 point-size: 9


### PR DESCRIPTION
Most font names explain which machine they're from.  The ST ones lack this context.  This patch amends that, bringing them inline with the others.